### PR TITLE
Delete old photo when new one uploaded.

### DIFF
--- a/backend/src/services/ImgUpload.js
+++ b/backend/src/services/ImgUpload.js
@@ -1,73 +1,100 @@
-'use strict';
-const Cloud = require('@google-cloud/storage');
-const Student = require('../models/Student');
-require('dotenv').config();
-const { Storage } = Cloud;
+'use strict'
+const Cloud = require('@google-cloud/storage')
+const Student = require('../models/Student')
+require('dotenv').config()
+const { Storage } = Cloud
 const gcs = new Storage({
     projectId: 'isa-icard',
     credentials: JSON.parse(process.env.GOOGLE_CLOUD_STORAGE_JSON),
 })
 
-const bucketName = 'isa-icard';
+const bucketName = 'isa-icard'
 // get a reference to the bucket that we want to upload to
-const bucket = gcs.bucket(bucketName);
+const bucket = gcs.bucket(bucketName)
 
 /**
- * 
- * @param {string} filename 
+ *
+ * @param {string} filename
  * @returns {string} public url
  */
 function getPublicUrl(filename) {
-    return `https://storage.googleapis.com/${bucketName}/${filename}`;
+    return `https://storage.googleapis.com/${bucketName}/${filename}`
 }
 
-let ImgUpload = {};
+/**
+ *
+ * @param {string} fileName
+ */
+async function deleteFile(fileName) {
+    await gcs.bucket(bucketName).file(fileName).delete()
+
+    console.log(
+        `old veerification image at gs://${bucketName}/${fileName} has been deleted`
+    )
+}
+
+let ImgUpload = {}
 
 // upload a file to the bucket and return the public url
-ImgUpload.uploadToGCS = async(req, res, next) => {
-
+ImgUpload.uploadToGCS = async (req, res, next) => {
     if (!req.user.email) {
         return res.status(400).json({
-            message: 'Email is required'
-        });
+            message: 'Email is required',
+        })
     }
-    
+
     // validate if the student exists in the database with the given email
-    const student = await Student.findOne({ email: req.user.email });
+    const student = await Student.findOne({ email: req.user.email })
     if (!student) {
         return res.status(400).json({
-            message: 'Student does not exist'
-        });
+            message: 'Student does not exist',
+        })
     }
 
     // check if the request has a file
     if (!req.file) {
-        return next();
+        return next()
+    }
+
+    console.log()
+    console.log(student) // student with current image
+    console.log(req.file) // image to upload
+
+    // delete the old verification image before new one uploaded
+    if ('verification_image' in student) {
+        console.log('there is already a verification image for this student')
+
+        const fileLink = student.verification_image
+        const lastSlash = fileLink.lastIndexOf('/')
+        const fileName = fileLink.slice(lastSlash + 1)
+
+        deleteFile(fileName).catch(console.error)
     }
 
     // Can optionally add a path to the gcsname below by concatenating it to the filename.
-    const gcsname = Date.now() + '-' + req.file.originalname;
-    const file = bucket.file(gcsname);
+    const gcsname = Date.now() + '-' + req.file.originalname
+    const file = bucket.file(gcsname)
 
-    const stream = file.createWriteStream({ // create a stream to upload the file to the bucket
+    const stream = file.createWriteStream({
+        // create a stream to upload the file to the bucket
         metadata: {
-            contentType: req.file.mimetype
-        }
-    });
+            contentType: req.file.mimetype,
+        },
+    })
 
     stream.on('error', (err) => {
-        req.file.cloudStorageError = err;
-        next(err);
-    }
-    );
+        req.file.cloudStorageError = err
+        next(err)
+    })
 
     stream.on('finish', () => {
-        req.file.cloudStorageObject = gcsname;
-        req.file.cloudStoragePublicUrl = getPublicUrl(gcsname);
-        next();
-    });
+        console.log('uploaded new verification image: ' + gcsname)
+        req.file.cloudStorageObject = gcsname
+        req.file.cloudStoragePublicUrl = getPublicUrl(gcsname)
+        next()
+    })
 
-    stream.end(req.file.buffer);    // end the stream and upload the file to the bucket
+    stream.end(req.file.buffer) // end the stream and upload the file to the bucket
 }
 
-module.exports = ImgUpload;
+module.exports = ImgUpload

--- a/backend/src/services/ImgUpload.js
+++ b/backend/src/services/ImgUpload.js
@@ -27,10 +27,6 @@ function getPublicUrl(filename) {
  */
 async function deleteFile(fileName) {
     await gcs.bucket(bucketName).file(fileName).delete()
-
-    console.log(
-        `old veerification image at gs://${bucketName}/${fileName} has been deleted`
-    )
 }
 
 let ImgUpload = {}
@@ -56,14 +52,8 @@ ImgUpload.uploadToGCS = async (req, res, next) => {
         return next()
     }
 
-    console.log()
-    console.log(student) // student with current image
-    console.log(req.file) // image to upload
-
     // delete the old verification image before new one uploaded
     if ('verification_image' in student) {
-        console.log('there is already a verification image for this student')
-
         const fileLink = student.verification_image
         const lastSlash = fileLink.lastIndexOf('/')
         const fileName = fileLink.slice(lastSlash + 1)
@@ -88,7 +78,6 @@ ImgUpload.uploadToGCS = async (req, res, next) => {
     })
 
     stream.on('finish', () => {
-        console.log('uploaded new verification image: ' + gcsname)
         req.file.cloudStorageObject = gcsname
         req.file.cloudStoragePublicUrl = getPublicUrl(gcsname)
         next()


### PR DESCRIPTION
Delete the old verification image from GCS when a new one is uploaded.
Ensured the backend is always up to date with recent upload verification image upload.

<img width="1280" alt="Screenshot 2022-10-30 at 2 46 51 PM" src="https://user-images.githubusercontent.com/83478026/198900787-0fd36b80-9b65-4c41-98ed-2018fff221c6.png">
