### PR TITLE
Renamed HomeView to Home in Web Views

### DIFF
--- a/web/icard-web/src/views/Home.jsx
+++ b/web/icard-web/src/views/Home.jsx
@@ -23,7 +23,7 @@ import {useState, useEffect, useContext} from 'react';
 //import AuthContext from '../context/AuthContext';
 //import {storeUser} from '../utilites/StoreUser';
 
-const HomeView = ({navigation}) => {
+const Home = ({navigation}) => {
   
   const [searchPhrase, setSearchPhrase] = useState('');
   const [clicked, setClicked] = useState(false);


### PR DESCRIPTION
Initial State:
-  the Home component was named HomeView in Home.jsx
-  Issues due the Home.jsx attempting to export a non-existent Home component
Fix:
- Renamed HomeView to Home in Home.jsx